### PR TITLE
Polish for launch: silent session, debounce, ghost text

### DIFF
--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -113,6 +113,13 @@ pub fn request_dismiss() -> Result<()> {
     Ok(())
 }
 
+/// Check if daemon is running (silent, no output).
+pub fn is_daemon_running() -> bool {
+    send_request(&Request::Status)
+        .map(|r| matches!(r, Response::StatusInfo { .. }))
+        .unwrap_or(false)
+}
+
 /// Check daemon status and print it.
 pub fn request_status() -> Result<()> {
     match send_request(&Request::Status)? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,10 +120,17 @@ enum Commands {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // Session mode defaults to warn (no visible logs).
+    // Other modes default to info. RUST_LOG overrides both.
+    let default_level = match &cli.command {
+        Commands::Session { .. } => "tabra=warn",
+        _ => "tabra=info",
+    };
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "tabra=info".into()),
+                .unwrap_or_else(|_| default_level.into()),
         )
         .init();
 

--- a/src/render/overlay.rs
+++ b/src/render/overlay.rs
@@ -78,7 +78,7 @@ pub fn render_popup(
     // This ensures there's room for the popup even when the cursor is near the
     // bottom of the terminal. The terminal scrolls the content up to make room.
     for _ in 0..total_popup_lines {
-        write!(out, "\n").ok();
+        writeln!(out).ok();
     }
     // Move cursor back up to where it was
     write!(out, "\x1b[{}A", total_popup_lines).ok();

--- a/src/session/event_loop.rs
+++ b/src/session/event_loop.rs
@@ -27,6 +27,10 @@ enum TerminalWrite {
     ErasePopup(usize),
     /// Erase old popup then show new one (atomic redraw).
     EraseAndShow(usize, String),
+    /// Show inline ghost text (dim suggestion after cursor, cleared on next keystroke).
+    GhostText(String),
+    /// Clear ghost text.
+    ClearGhost(usize),
 }
 
 /// Run the session event loop. This is the main entry point after PTY setup.
@@ -149,15 +153,73 @@ pub async fn run(
         debug!("stdin reader exited");
     });
 
+    // Debounce channel: CommandLine OSC events are buffered and only the latest
+    // is processed after 30ms of no new events. This prevents re-rendering the
+    // popup on every keystroke during fast typing.
+    let (debounce_tx, mut debounce_rx) = mpsc::channel::<(String, usize)>(16);
+    let debounce_popup = popup.clone();
+    let debounce_write_tx = write_tx.clone();
+    let debounce_task = tokio::spawn(async move {
+        let cwd = std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let debounce_dur = std::time::Duration::from_millis(30);
+
+        loop {
+            let (mut buffer, mut cursor) = match debounce_rx.recv().await {
+                Some(ev) => ev,
+                None => break,
+            };
+            // Drain pending events, keep only the latest
+            loop {
+                match tokio::time::timeout(debounce_dur, debounce_rx.recv()).await {
+                    Ok(Some((b, c))) => {
+                        buffer = b;
+                        cursor = c;
+                    }
+                    _ => break,
+                }
+            }
+            let mut p = debounce_popup.lock().await;
+
+            // Clear previous ghost text
+            if p.ghost_len > 0 {
+                let _ = debounce_write_tx
+                    .send(TerminalWrite::ClearGhost(p.ghost_len))
+                    .await;
+                p.ghost_len = 0;
+            }
+
+            let action = p.on_command_line(buffer.clone(), cursor, &cwd).await;
+            dispatch_popup_action(action, &debounce_write_tx).await;
+
+            // Show ghost text: the remaining part of the first suggestion
+            if !p.items.is_empty() {
+                let first_insert = p.items[0].insert.clone();
+                let token_start = p.find_token_start();
+                let end = cursor.min(buffer.len());
+                if token_start <= end {
+                    let current_token = &buffer[token_start..end];
+                    if first_insert.starts_with(current_token)
+                        && first_insert.len() > current_token.len()
+                    {
+                        let ghost = &first_insert[current_token.len()..];
+                        p.ghost_len = ghost.len();
+                        let _ = debounce_write_tx
+                            .send(TerminalWrite::GhostText(ghost.to_string()))
+                            .await;
+                    }
+                }
+            }
+        }
+    });
+
     // Task 2: Process PTY output from read thread, strip OSC, forward to terminal
     let pty_popup = popup.clone();
     let pty_terminal_tx = write_tx.clone();
     let pty_task = tokio::spawn(async move {
         let mut osc_parser = OscParser::new();
-        let cwd = std::env::current_dir()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
 
         while let Some(chunk) = pty_output_rx.recv().await {
             let (passthrough, events) = osc_parser.feed(&chunk);
@@ -171,9 +233,8 @@ pub async fn run(
             for event in events {
                 match event {
                     OscEvent::CommandLine { buffer, cursor } => {
-                        let mut popup = pty_popup.lock().await;
-                        let action = popup.on_command_line(buffer, cursor, &cwd).await;
-                        dispatch_popup_action(action, &pty_terminal_tx).await;
+                        // Debounce: send to channel, process after 30ms of quiet
+                        let _ = debounce_tx.send((buffer, cursor)).await;
                     }
                     OscEvent::PromptStart => {
                         let mut popup = pty_popup.lock().await;
@@ -225,6 +286,22 @@ pub async fn run(
                     let _ = stdout.write_all(b"\x1b[u");
                     let _ = stdout.flush();
                 }
+                TerminalWrite::GhostText(text) => {
+                    // Save cursor, write dim text, restore cursor
+                    // The ghost text appears after the cursor in dim gray
+                    let _ = stdout.write_all(b"\x1b[s\x1b[90m");
+                    let _ = stdout.write_all(text.as_bytes());
+                    let _ = stdout.write_all(b"\x1b[0m\x1b[u");
+                    let _ = stdout.flush();
+                }
+                TerminalWrite::ClearGhost(len) => {
+                    // Save cursor, overwrite ghost text with spaces, restore
+                    let _ = stdout.write_all(b"\x1b[s");
+                    let spaces = " ".repeat(len);
+                    let _ = stdout.write_all(spaces.as_bytes());
+                    let _ = stdout.write_all(b"\x1b[u");
+                    let _ = stdout.flush();
+                }
             }
         }
         debug!("terminal writer exited");
@@ -272,6 +349,9 @@ pub async fn run(
     sigwinch_task.abort();
     let _ = sigwinch_task.await;
 
+    debounce_task.abort();
+    let _ = debounce_task.await;
+
     pty_writer_task.abort();
     let _ = pty_writer_task.await;
 
@@ -297,6 +377,45 @@ async fn handle_key_event(
     write_tx: &mpsc::Sender<TerminalWrite>,
     pty_tx: &mpsc::Sender<Vec<u8>>,
 ) {
+    // ArrowRight with ghost text: accept ghost text by typing it into the shell
+    if event == KeyEvent::ArrowRight {
+        let mut p = popup.lock().await;
+        if p.ghost_len > 0 && !p.items.is_empty() {
+            let first_insert = p.items[0].insert.clone();
+            let current_token_start = p.find_token_start();
+            let current_token =
+                &p.last_buffer[current_token_start..p.last_cursor.min(p.last_buffer.len())];
+            if first_insert.starts_with(current_token) {
+                let remaining = &first_insert[current_token.len()..];
+                // Clear ghost text
+                let _ = write_tx.send(TerminalWrite::ClearGhost(p.ghost_len)).await;
+                p.ghost_len = 0;
+                // Type the remaining text into the shell
+                let mut inject = remaining.as_bytes().to_vec();
+                inject.push(b' '); // add space after completion
+                let _ = pty_tx.send(inject).await;
+                // Hide popup
+                if p.visible {
+                    let lines = p.popup_lines;
+                    p.visible = false;
+                    p.items.clear();
+                    p.popup_lines = 0;
+                    let _ = write_tx.send(TerminalWrite::ErasePopup(lines)).await;
+                }
+                return;
+            }
+        }
+        drop(p);
+    }
+
+    // Clear ghost text on any keystroke (it'll be re-rendered after debounce)
+    {
+        let mut p = popup.lock().await;
+        if p.ghost_len > 0 {
+            let _ = write_tx.send(TerminalWrite::ClearGhost(p.ghost_len)).await;
+            p.ghost_len = 0;
+        }
+    }
     let action = popup.lock().await.on_key(&event);
     match action {
         PopupAction::ForwardKey(bytes) => {

--- a/src/session/event_loop.rs
+++ b/src/session/event_loop.rs
@@ -172,14 +172,11 @@ pub async fn run(
                 None => break,
             };
             // Drain pending events, keep only the latest
-            loop {
-                match tokio::time::timeout(debounce_dur, debounce_rx.recv()).await {
-                    Ok(Some((b, c))) => {
-                        buffer = b;
-                        cursor = c;
-                    }
-                    _ => break,
-                }
+            while let Ok(Some((b, c))) =
+                tokio::time::timeout(debounce_dur, debounce_rx.recv()).await
+            {
+                buffer = b;
+                cursor = c;
             }
             let mut p = debounce_popup.lock().await;
 
@@ -385,8 +382,7 @@ async fn handle_key_event(
             let current_token_start = p.find_token_start();
             let current_token =
                 &p.last_buffer[current_token_start..p.last_cursor.min(p.last_buffer.len())];
-            if first_insert.starts_with(current_token) {
-                let remaining = &first_insert[current_token.len()..];
+            if let Some(remaining) = first_insert.strip_prefix(current_token) {
                 // Clear ghost text
                 let _ = write_tx.send(TerminalWrite::ClearGhost(p.ghost_len)).await;
                 p.ghost_len = 0;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -34,9 +34,8 @@ pub fn run(shell: Option<ShellType>) -> Result<()> {
 
     info!("starting session with shell: {}", shell_path);
 
-    // Ensure daemon is running
-    if tabra::ipc::client::request_status().is_err() {
-        info!("daemon not running, starting...");
+    // Ensure daemon is running (silently)
+    if !tabra::ipc::client::is_daemon_running() {
         std::process::Command::new("tabra")
             .arg("daemon")
             .stdin(std::process::Stdio::null())
@@ -45,10 +44,9 @@ pub fn run(shell: Option<ShellType>) -> Result<()> {
             .spawn()
             .context("failed to start tabra daemon")?;
 
-        // Wait for daemon to be ready
         for _ in 0..10 {
             std::thread::sleep(std::time::Duration::from_millis(100));
-            if tabra::ipc::client::request_status().is_ok() {
+            if tabra::ipc::client::is_daemon_running() {
                 break;
             }
         }

--- a/src/session/popup.rs
+++ b/src/session/popup.rs
@@ -43,6 +43,8 @@ pub struct PopupState {
     pub terminal_cols: u16,
     pub theme: Theme,
     pub popup_lines: usize,
+    /// Length of the current ghost text (for clearing).
+    pub ghost_len: usize,
 }
 
 impl PopupState {
@@ -56,6 +58,7 @@ impl PopupState {
             terminal_cols,
             theme: Theme::default(),
             popup_lines: 0,
+            ghost_len: 0,
         }
     }
 
@@ -236,7 +239,7 @@ impl PopupState {
 
     /// Find the start of the current token in the last known buffer.
     /// Uses a forward walk matching the Rust parser's tokenizer logic.
-    fn find_token_start(&self) -> usize {
+    pub fn find_token_start(&self) -> usize {
         let before = &self.last_buffer[..self.last_cursor.min(self.last_buffer.len())];
         let mut last_boundary = 0;
         let mut in_sq = false;


### PR DESCRIPTION
## Summary
Three fixes to make Tabra ready for public launch:

1. **Silent session**: no logs or daemon status in terminal output
2. **Debounce (30ms)**: no popup re-render during fast typing, only after pause
3. **Inline ghost text**: first suggestion in dim gray after cursor, ArrowRight to accept

## Test plan
- [ ] `tabra session` starts with clean prompt (no INFO logs)
- [ ] Fast typing doesn't cause flicker (popup only appears after 30ms pause)
- [ ] Ghost text appears after cursor in gray
- [ ] ArrowRight accepts ghost text
- [ ] CI green